### PR TITLE
get_parents and mix_parents functions

### DIFF
--- a/Feature Selection/Feature selection.ipynb
+++ b/Feature Selection/Feature selection.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "8a5ff41f",
    "metadata": {},
    "outputs": [],
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "b9bc3b71",
    "metadata": {},
    "outputs": [],
@@ -33,11 +33,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "b7b1c3ef",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "def get_parents(parent_F:list):\n",
+    "\tlevels  = np.array(parent_F)[:, 2]\n",
+    "\tmax_idx = np.argmin(levels)\n",
+    "\treturn parent_F[max_idx]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bdd08f32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mix_parents(parent_a:list, parent_b:list, ratio:float = 0.5, get_indexes:bool=False):\n",
+    "\tgenotype_len = len(parent_a)\n",
+    "\n",
+    "\ta_idxs = set()\n",
+    "\tacum = 0\n",
+    "\tfor i in range(genotype_len):\n",
+    "\t\tacum += ratio\n",
+    "\t\tif acum >= 1:\n",
+    "\t\t\tacum -= 1\n",
+    "\t\t\ta_idxs.add(i)\n",
+    "\tb_idxs = {i for i in range(genotype_len)} - a_idxs\n",
+    "\n",
+    "\ta_idxs = list(a_idxs)\n",
+    "\tb_idxs = list(b_idxs)\n",
+    "\tchild  = np.zeros((genotype_len), bool)\n",
+    "\n",
+    "\tchild[a_idxs] = parent_a[a_idxs].copy()\n",
+    "\tchild[b_idxs] = parent_b[b_idxs].copy()\n",
+    "\tif get_indexes:\n",
+    "\t\treturn child, (a_idxs, b_idxs)\n",
+    "\treturn child"
+   ]
   }
  ],
  "metadata": {
@@ -56,7 +91,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added the *get_parents* function
- Selects the first lowest level parent in a list of candidate parents
- Returns the reference to the parent

Added the *mix_parents* function
- Takes two parents and creates a child combining the two parents
- The ratio of how much it receives from a parent can be passed as an argument
- Combines them using an intercalated approach; if the ratio is 0.5, the first element will be from parent b, then from parent a, and so on.
- The ratio affects the frecuency of the elements so that the closer it is to 1, the more like parent a the child will be, and the closer to 0, the more like parent b